### PR TITLE
add support for http proxy

### DIFF
--- a/src/main/java/org/web3j/spring/autoconfigure/Web3jAutoConfiguration.java
+++ b/src/main/java/org/web3j/spring/autoconfigure/Web3jAutoConfiguration.java
@@ -19,6 +19,11 @@ import org.web3j.protocol.ipc.UnixIpcService;
 import org.web3j.protocol.ipc.WindowsIpcService;
 import org.web3j.spring.actuate.Web3jHealthIndicator;
 
+import java.net.InetSocketAddress;
+import java.net.MalformedURLException;
+import java.net.Proxy;
+import java.net.URL;
+import java.util.Objects;
 import java.util.concurrent.TimeUnit;
 
 import okhttp3.OkHttpClient;
@@ -72,6 +77,7 @@ public class Web3jAutoConfiguration {
 
     private OkHttpClient createOkHttpClient() {
         OkHttpClient.Builder builder = new OkHttpClient.Builder();
+        configureProxy(builder);
         configureLogging(builder);
         configureTimeouts(builder);
         return builder.build();
@@ -83,6 +89,17 @@ public class Web3jAutoConfiguration {
             builder.connectTimeout(tos, TimeUnit.SECONDS);
             builder.readTimeout(tos, TimeUnit.SECONDS);  // Sets the socket timeout too
             builder.writeTimeout(tos, TimeUnit.SECONDS);
+        }
+    }
+
+    private void configureProxy(OkHttpClient.Builder builder) {
+        if (properties.getProxyUrl() != null) {
+            try {
+                URL proxyUrl = new URL(properties.getProxyUrl());
+                Proxy proxy = new Proxy(Objects.equals(proxyUrl.getProtocol(), "http") ? Proxy.Type.HTTP : Proxy.Type.SOCKS, new InetSocketAddress(proxyUrl.getHost(), proxyUrl.getPort()));
+                builder.proxy(proxy);
+            } catch (MalformedURLException ignored) {
+            }
         }
     }
 

--- a/src/main/java/org/web3j/spring/autoconfigure/Web3jProperties.java
+++ b/src/main/java/org/web3j/spring/autoconfigure/Web3jProperties.java
@@ -20,6 +20,9 @@ public class Web3jProperties {
 
     private Long httpTimeoutSeconds;
 
+
+    private String proxyUrl;
+
     public String getClientAddress() {
         return clientAddress;
     }
@@ -51,5 +54,12 @@ public class Web3jProperties {
     public void setHttpTimeoutSeconds(Long httpTimeoutSeconds) {
         this.httpTimeoutSeconds = httpTimeoutSeconds;
     }
+
+    public String getProxyUrl() { return proxyUrl; }
+
+    public void setProxyUrl(String proxyUrl) {
+        this.proxyUrl = proxyUrl;
+    }
+
     
 }


### PR DESCRIPTION
Add support for http proxy, to be able to use this starter when behind a corporate proxy

A new property proxy-url has been added to specify the proxy
Example of use :
proxy-url: http;//proxy.my-company.net:8080
