### PR TITLE
bump up web3j to 4.8.7

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -29,7 +29,7 @@ sourceCompatibility = 1.8
 targetCompatibility = 1.8
 
 ext {
-    web3jVersion = '4.0.3'
+    web3jVersion = '4.8.7'
     springBootVersion = '2.0.6.RELEASE'
 
     ossrhUsername = project.hasProperty('ossrhUsername') ? project.property('ossrhUsername') : System.getenv('OSSRH_USERNAME')


### PR DESCRIPTION
### What does this PR do?
Bump up web3j version to 4.8.7.

### Where should the reviewer start?
The change is self-explanatory.

### Why is it needed?
It has been over 4 years since the last [web3j-spring-boot-starter](https://github.com/web3j/web3j-spring-boot-starter) release. A lot has been changed in web3j. We need to catch up with the latest change.
